### PR TITLE
modify some package and training issues

### DIFF
--- a/node_cls_pytorch/train_inits_node_cls.py
+++ b/node_cls_pytorch/train_inits_node_cls.py
@@ -69,7 +69,7 @@ class LR(torch.nn.Module):
         self.fc_1 = torch.nn.Linear(dim, 10)
         self.fc_2 = torch.nn.Linear(10, 1)
         self.act = torch.nn.ReLU()
-        self.dropout = torch.nn.Dropout(p=drop, inplace=True)
+        self.dropout = torch.nn.Dropout(p=drop)
 
     def forward(self, x):
         x = self.act(self.fc_1(x))

--- a/node_cls_pytorch/utils/dynamic_graph_transformer_utils.py
+++ b/node_cls_pytorch/utils/dynamic_graph_transformer_utils.py
@@ -97,14 +97,14 @@ def generate_compressed_graphs(graphs, alpha = 0.15, max_dist=5): # Checked
     
     #### edge_dist_encode
     st = time.time()
-    adj = nx.to_scipy_sparse_matrix(graphs[-1])
+    adj = nx.to_scipy_sparse_array(graphs[-1])
     edge_dist_encode = compute_shortest_path_dist(adj, max_dist)
     print('Compute Edge encoding takes time', time.time() - st)
 
     #### PPR
     st = time.time()
     sparse_edge_exist = csr_matrix((edge_encode_all_data, (edge_encode_all_row, edge_encode_all_col)), shape=(num_nodes, num_nodes))
-    G = nx.from_scipy_sparse_matrix(sparse_edge_exist)
+    G = nx.from_scipy_sparse_array(sparse_edge_exist)
     PPR = np.array(nx.google_matrix(G, alpha), dtype=np.float32)
     print('Compute PPR takes time', time.time() - st)    
 


### PR DESCRIPTION
Network 3.0+ will not support "nx.to_scipy_sparse_matrix" and "nx.from_scipy_sparse_matrix". Change them to "nx.to_scipy_sparse_array" and "nx.from_scipy_sparse_array".

When training, some inplace operations will lead to gradient failing to compute. I have solved this issue and node classification training is ok. 
